### PR TITLE
Radiant.config for assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ log/*.log
 tmp/**/*
 
 db/schema.rb
+
+*.swp

--- a/app/views/admin/configuration/_edit.html.haml
+++ b/app/views/admin/configuration/_edit.html.haml
@@ -1,0 +1,16 @@
+%fieldset
+  %h3 Assets
+  %p= edit_config 'assets.storage'
+  %p= edit_config 'assets.display_size'
+  %p= edit_config 'assets.additional_thumbnails'
+  %p= edit_config 'assets.url'
+  %p= edit_config 'assets.path'
+  %p= edit_config 'assets.content_types'
+  %p= edit_config 'assets.skip_filetype_validation'
+  %p= edit_config 'assets.max_asset_size'
+
+%fieldset
+  %h3 Amazon Credentials
+  %p= edit_config 'assets.s3.bucket'
+  %p= edit_config 'assets.s3.key'
+  %p= edit_config 'assets.s3.secret'

--- a/app/views/admin/configuration/_show.html.haml
+++ b/app/views/admin/configuration/_show.html.haml
@@ -1,0 +1,26 @@
+%h4 Assets
+%p.ruled
+  = show_config 'assets.storage'
+%p.ruled
+  = show_config 'assets.display_size'
+%p.ruled
+  = show_config 'assets.additional_thumbnails'
+%p.ruled
+  = show_config 'assets.url'
+%p.ruled
+  = show_config 'assets.path'
+%p.ruled
+  = show_config 'assets.content_types'
+%p.ruled
+  = show_config 'assets.skip_filetype_validation'
+%p.ruled
+  = show_config 'assets.max_asset_size'
+
+- if Radiant.config["assets.storage"] == "s3"
+  %h4 Amazon Credentials
+  %p.ruled
+    = show_config 'assets.s3.bucket'
+  %p.ruled
+    = show_config 'assets.s3.key'
+  %p.ruled
+    = show_config 'assets.s3.secret'

--- a/assets_extension.rb
+++ b/assets_extension.rb
@@ -6,47 +6,50 @@ class AssetsExtension < Radiant::Extension
   version "1.0"
   description "Assets extension based Keith Bingman's original Paperclipped extension."
   url "http://github.com/radiant/radiant-assets-extension"
-  
+
   def activate
     Page.send :include, PageAssetAssociations                                          # defines page-asset associations. likely to be generalised soon.
     Radiant::AdminUI.send :include, AssetsAdminUI unless defined? admin.asset          # defines shards for extension of the asset-admin interface
     Admin::PagesController.send :helper, Admin::AssetsHelper                           # currently only provides a description of asset sizes
     Page.send :include, AssetTags                                                      # radius tags for selecting sets of assets and presenting each one
     UserActionObserver.instance.send :add_observer!, Asset                             # the usual creator- and updater-stamping
-    
+
     AssetType.new :image, :mime_types => %w[image/png image/x-png image/jpeg image/pjpeg image/jpg image/gif], :processors => [:thumbnail], :styles => {:icon => ['42x42#', :png], :thumbnail => ['100x100>', :png]}
     AssetType.new :video, :mime_types => %w[video/mpeg video/mp4 video/ogg video/quicktime video/x-ms-wmv video/x-flv]
     AssetType.new :audio, :mime_types => %w[audio/mpeg audio/mpg audio/ogg application/ogg audio/x-ms-wma audio/vnd.rn-realaudio audio/x-wav]
-    AssetType.new :swf, :mime_types => %w[application/x-shockwave-flash]
-    AssetType.new :pdf, :mime_types => %w[application/pdf application/x-pdf]
+    AssetType.new :swf,   :mime_types => %w[application/x-shockwave-flash]
+    AssetType.new :pdf,   :mime_types => %w[application/pdf application/x-pdf]
     AssetType.new :movie, :mime_types => AssetType.mime_types_for(:video, :swf)        # this is an alias for backwards-compatibility: movie could previously be either video or flash. (existing mime-type lookup table is not affected but methods like Asset#movie? are created)
     AssetType.new :other                                                               #  # an AssetType declared with no (or unknown) mime-types is filed under 'everything else'
-    
+
     admin.asset ||= Radiant::AdminUI.load_default_asset_regions                        # loads the shards defined above
     # admin.page.edit.add :main, "/admin/assets/show_bucket_link", :before => "edit_header"  
-    admin.pages.edit.add :part_controls, 'admin/assets/show_bucket_link'   
+    admin.pages.edit.add :part_controls, 'admin/assets/show_bucket_link'
     admin.page.edit.add :main, "/admin/assets/assets_bucket", :after => "edit_buttons"
     admin.page.edit.asset_tabs.concat %w{attachment_tab upload_tab bucket_tab search_tab}
     admin.page.edit.bucket_pane.concat %w{bucket_notes bucket bucket_bottom}
     admin.page.edit.asset_panes.concat %w{page_attachments upload search}
-    
+
+    admin.configuration.show.add :config, 'admin/configuration/show', :after => 'defaults'
+    admin.configuration.edit.add :form,   'admin/configuration/edit', :after => 'edit_defaults'
+
     if Radiant::Config.table_exists? && Radiant::Config["assets.image_magick_path"]    # This is just needed for testing if you are using mod_rails
       Paperclip.options[:image_magick_path] = Radiant::Config["assets.image_magick_path"]
     end
-    
+
     tab "Assets", :after => "Content" do
       add_item "All", "/admin/assets/"
     end
-    
+
     update_sass_each_request if RAILS_ENV == 'development'
   end
-  
+
   def deactivate
-    
+
   end
-  
+
   private
-  
+
     def update_sass_each_request
       ApplicationController.class_eval do
         prepend_before_filter :update_assets_sass

--- a/config/initializers/assets_config.rb
+++ b/config/initializers/assets_config.rb
@@ -1,0 +1,21 @@
+Radiant.config do |config|
+  config.namespace 'assets', :allow_display => false do |assets|
+    assets.define 'display_size',             :default => 'normal'
+    assets.define 'additional_thumbnails',    :default => 'normal=640x640>'
+    assets.define 'url',                      :default => '/:class/:id/:basename:no_original_style.:extension'
+    assets.define 'path',                     :default => ':rails_root/public/:class/:id/:basename:no_original_style.:extension'
+    assets.define 'content_types',            :default => 'image/jpeg, image/pjpeg, image/gif, image/png, image/x-png, image/jpg, video/x-m4v, video/quicktime, application/x-shockwave-flash, audio/mpeg, video/mpeg'
+    assets.define 'skip_filetype_validation', :default => true, :type => :boolean
+    assets.define 'max_asset_size',           :default => 5,    :type => :integer
+
+    assets.define 'storage', :default     => 'filesystem',
+                             :select_from => {'File System' => 'filesystem', 'Amazon S3' => 's3'},
+                             :allow_blank => false
+
+    assets.namespace 's3', :allow_display => false do |s3|
+      s3.define 'bucket'
+      s3.define 'key'
+      s3.define 'secret'
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,13 +1,13 @@
 ---
 en:
-  
+
   assets: 'Assets'
   all:    'All'
   images: 'Images'
   others: 'Others'
   audio:  'Audio'
   movies: 'Movies'
-  
+
   activerecord:
     errors:
       models:
@@ -15,9 +15,9 @@ en:
           attributes:
             asset:
               blank: 'You must choose a file to upload!'
-  
+
   assets_extension:
-    actions: Actions
+    actions: 'Actions'
     add_asset_to_bucket: 'Add Asset to Bucket'
     add_to_bucket: 'Add to Bucket'
     all: 'All'
@@ -71,7 +71,22 @@ en:
     search: 'Search'
     show_assets_bucket: 'Show Assets Bucket'
     title: 'Title'
-    type: 'Type'  
+    type: 'Type'
     types_to_find: 'Types to find'
     upload: 'Upload'
     upload_asset: 'Upload Asset'
+
+  config:
+    assets:
+      additional_thumbnails: 'Additional Thumbnails'
+      content_types: 'Content Types'
+      display_size: 'Display Size'
+      max_asset_size: 'Max Asset Size'
+      path: 'Path'
+      skip_filetype_validation: 'Skip Filetype Validation'
+      storage: 'Storage'
+      url: 'Url'
+      s3:
+        bucket: 'Bucket'
+        key: 'Key'
+        secret: 'Secret'

--- a/db/migrate/006_add_default_configs.rb
+++ b/db/migrate/006_add_default_configs.rb
@@ -1,17 +1,16 @@
 class AddDefaultConfigs < ActiveRecord::Migration
-  
+
   class Config < ActiveRecord::Base; end
-  
+
   def self.up
-    Radiant::Config['assets.additional_thumbnails'] = "normal=640x640>"
-    Radiant::Config['assets.display_size'] = "original"
-    puts "-- Setting default display sizes in Radiant::Config"
     if defined? SettingsExtension && Radiant::Config.column_names.include?('description')
+      puts "-- Adding Settings Extension descriptions for assets.additional_thumbnails & assets.display_size"
+
       Config.find(:all).each do |c|
        description = case c.key
          when 'assets.additional_thumbnails'
            'Defines the default sizes for image assets that are created when an image is uploaded. Use "#" to crop the image to a specific size. "42x42#" would be a square thumbnail, cropped in the center 42 pixels by 42 pixels.'
-       
+
          when 'assets.display_size'
            'Sets which of your image sizes is shown is the edit view. Defaults to the "original" image size, but any size may be used. '
          else
@@ -23,7 +22,5 @@ class AddDefaultConfigs < ActiveRecord::Migration
   end
 
   def self.down
-
   end
-  
 end

--- a/db/migrate/007_add_default_content_types.rb
+++ b/db/migrate/007_add_default_content_types.rb
@@ -1,17 +1,16 @@
 class AddDefaultContentTypes < ActiveRecord::Migration
-  
+
   class Config < ActiveRecord::Base; end
-  
+
   def self.up
-    Radiant::Config['assets.content_types'] =  "image/jpeg, image/pjpeg, image/gif, image/png, image/x-png, image/jpg, video/x-m4v, video/quicktime, application/x-shockwave-flash, audio/mpeg, video/mpeg"
-    Radiant::Config['assets.max_asset_size'] = 5
-    puts "-- Setting default content types in Radiant::Config"
     if defined? SettingsExtension && Radiant::Config.column_names.include?('description')
+      puts "-- Adding Settings Extension descriptions for assets.content_types & assets.max_asset_size"
+
       Config.find(:all).each do |c|
        description = case c.key
          when 'assets.content_types'
            'Defines the content types of that will be allowed to be uploaded as assets.'
-       
+
          when 'assets.max_asset_size'
            'The size in megabytes that will be the max size allowed to be uploaded for an asset'
          else
@@ -23,7 +22,5 @@ class AddDefaultContentTypes < ActiveRecord::Migration
   end
 
   def self.down
-
   end
-  
 end

--- a/db/migrate/20090316132151_disable_file_types.rb
+++ b/db/migrate/20090316132151_disable_file_types.rb
@@ -1,8 +1,8 @@
 class DisableFileTypes < ActiveRecord::Migration
   def self.up
-    Radiant::Config['assets.skip_filetype_validation'] = true
-    puts "-- Setting default content types in Radiant::Config"
     if defined? SettingsExtension && Radiant::Config.column_names.include?('description')
+      puts "-- Adding Settings Extension descriptions for assets.skip_filetype_validations"
+
       Radiant::Config.find(:all).each do |c|
        description = case c.key
          when 'assets.skip_filetype_validations'


### PR DESCRIPTION
I was looking over Edge Radiant and noticed the new Settings config screens and thought I would have a play around to see whats possible within extensions. So I went about setting up a config for the assets extension. Not sure if it's what you've planned for assets, I was just testing things out and thought I'd pass on what I've done. Seems like the right approach to me having all settings configured in one location. Rough list of changes below :
- Created config/initializers/assets_config.rb
- Added show / edit partials for the settings admin
- Added translations
- Removed duplicated config settings from the migrations and the main Asset class
