### PR TITLE
Updated the assets title to be an h3 in the edit config view

### DIFF
--- a/app/views/admin/configuration/_clipped_edit.html.haml
+++ b/app/views/admin/configuration/_clipped_edit.html.haml
@@ -1,5 +1,5 @@
 %fieldset
-  %h4 
+  %h3
     = t('clipped_extension.assets')
   %p= edit_config 'assets.max_asset_size'
   %p= edit_config 'assets.display_size'


### PR DESCRIPTION
It should only be an h4 in the `show` view.

If you look, everything else uses an h3 and the assets title appears smaller than the other sections.
