### PR TITLE
Update paperclip version

### DIFF
--- a/radiant-clipped-extension.gemspec
+++ b/radiant-clipped-extension.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = RadiantClippedExtension::DESCRIPTION
 
   s.add_dependency "acts_as_list", "0.1.4"
-  s.add_dependency "paperclip",    "~> 2.5.0"
+  s.add_dependency "paperclip",    "~> 2.6.0"
   s.add_dependency "uuidtools",    "~> 2.1.2"
 
   ignores = if File.exist?('.gitignore')


### PR DESCRIPTION
After updating a site to all the latest and greatest (radiant 1.0.1, ruby 1.9.3), multi-file upload was broken for me.
The upload process would return a 500 error after the first or nth succesful save because a tmp file went missing.
I found https://github.com/thoughtbot/paperclip/commit/c21f0fbf83b5c5edf69134be9a8b5ad7135e2ebc to help, so I updated the paperclip version requirement.

Could somebody with rubygem rights release a new version plz?
Yes, looking at you @saturnflyer, @will-r and @johnmuhl
