### PR TITLE
Refactor to use rails image_tag helper

### DIFF
--- a/lib/asset_tags.rb
+++ b/lib/asset_tags.rb
@@ -1,5 +1,7 @@
 module AssetTags
   include Radiant::Taggable
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::AssetTagHelper
   
   class TagError < StandardError; end
   
@@ -230,9 +232,8 @@ module AssetTags
     size = options.delete('size') || 'original'
     raise TagError, "asset #{tag.locals.asset.title} has no '#{size}' thumbnail" unless tag.locals.asset.has_style?(size)
     options['alt'] ||= tag.locals.asset.title
-    attributes = options.inject('') { |s, (k, v)| s << %{#{k.downcase}="#{v}" } }.strip
     url = tag.locals.asset.thumbnail(size)
-    %{<img src="#{url}" #{attributes} />} rescue nil
+    image_tag url, options rescue nil
   end
   
   desc %{


### PR DESCRIPTION
Currently, the clipped extension does not respect the rails asset_host. This means that if a CDN has been configured to host assets, it will not work with the clipped-extension.
